### PR TITLE
Disable Windows Update related settings in Safe Mode without networking support

### DIFF
--- a/Panels/Img_Ops/Capabilities/AddCapabilities.vb
+++ b/Panels/Img_Ops/Capabilities/AddCapabilities.vb
@@ -306,7 +306,12 @@ Public Class AddCapabilities
         CheckBox3.ForeColor = ForeColor
         ListView1.ForeColor = ForeColor
         RichTextBox1.ForeColor = ForeColor
-        CheckBox2.Enabled = MainForm.OnlineManagement = True
+        If MainForm.OnlineManagement And (SystemInformation.BootMode = BootMode.Normal Or SystemInformation.BootMode = BootMode.FailSafeWithNetwork) Then
+            CheckBox2.Enabled = True
+        Else
+            CheckBox2.Checked = False
+            CheckBox2.Enabled = False
+        End If
         CheckBox3.Enabled = MainForm.OnlineManagement = False
         Dim handle As IntPtr = MainForm.GetWindowHandle(Me)
         If MainForm.IsWindowsVersionOrGreater(10, 0, 18362) Then MainForm.EnableDarkTitleBar(handle, MainForm.BackColor = Color.FromArgb(48, 48, 48))

--- a/Panels/Img_Ops/CompClean/ImgCleanup.vb
+++ b/Panels/Img_Ops/CompClean/ImgCleanup.vb
@@ -327,7 +327,12 @@ Public Class ImgCleanup
             End Using
         End If
 
-        CheckBox5.Enabled = MainForm.OnlineManagement = True
+        If MainForm.OnlineManagement And (SystemInformation.BootMode = BootMode.Normal Or SystemInformation.BootMode = BootMode.FailSafeWithNetwork) Then
+            CheckBox5.Enabled = True
+        Else
+            CheckBox5.Checked = False
+            CheckBox5.Enabled = False
+        End If
 
         If SelTask >= 0 And SelTask < ComboBox1.Items.Count Then ComboBox1.SelectedIndex = SelTask
     End Sub

--- a/Panels/Img_Ops/Features/EnableFeat.vb
+++ b/Panels/Img_Ops/Features/EnableFeat.vb
@@ -324,8 +324,13 @@ Public Class EnableFeat
             Case 3
                 Label2.Text &= " Seules les caractéristiques désactivées (" & ListView1.Items.Count & ") sont représentées"
         End Select
-        CheckBox4.Enabled = MainForm.OnlineManagement = True
         CheckBox5.Enabled = MainForm.OnlineManagement = False
+        If MainForm.OnlineManagement And (SystemInformation.BootMode = BootMode.Normal Or SystemInformation.BootMode = BootMode.FailSafeWithNetwork) Then
+            CheckBox4.Enabled = True
+        Else
+            CheckBox4.Checked = False
+            CheckBox4.Enabled = False
+        End If
         Dim handle As IntPtr = MainForm.GetWindowHandle(Me)
         If MainForm.IsWindowsVersionOrGreater(10, 0, 18362) Then MainForm.EnableDarkTitleBar(handle, MainForm.BackColor = Color.FromArgb(48, 48, 48))
     End Sub


### PR DESCRIPTION
This PR closes #56, by disabling the WU contact/limit options when the system is in Safe Mode without networking support and in online installation management mode. It's still enabled in Normal mode or in Safe Mode with networking